### PR TITLE
Animations update

### DIFF
--- a/css/index-styles.css
+++ b/css/index-styles.css
@@ -69,7 +69,7 @@ html, body {
 
 #keynote_speakers {
     opacity: 0;
-    transition: 0.35s;
+    transition: 0.8s;
 }
 
 #keynote_speakers.shown {
@@ -78,17 +78,30 @@ html, body {
 
 /* Brief Info and Conference Synopsis Styles */
 
-.section#first {
-    transform: translateX(-110%);
+.section#first div.content {
+    transform: translateX(-200%);
     transition: 1s ease;
 }
 
-.section#second {
-    transform: translateX(110%);
+.section#first img {
+    transform: translateX(-400%);
+    transition: 1s ease;
+    animation-delay: 0.35s;
+}
+
+.section#second div.content {
+    transform: translateX(200%);
     transition: 1s ease;
 }
 
-.section.show-me#first, .section.show-me#second {
+.section#second img {
+    transform: translateX(400%);
+    transition: 1s ease;
+    animation-delay: 0.25s;
+}
+
+.section.show-me#first div.content, .section.show-me#second div.content, 
+.section.show-me#first img, .section.show-me#second img {
     transform: none;
 }
 
@@ -99,6 +112,11 @@ html, body {
 .elaboration_para {
     padding-top: 20px;
     font-size: 18px;
+}
+
+article#conference_synopsis img {
+    position: relative;
+    z-index: 10;
 }
 
 /* Vertical Line */

--- a/html/index.html
+++ b/html/index.html
@@ -109,7 +109,7 @@
         <article class="container-fluid p-5" id="brief_info">
             <div class="section" id="first">
                 <article class="row mx-auto">
-                    <div class="col-lg-6 text-right">
+                    <div class="col-lg-6 text-right content">
                         <h1 class="vl_right">Brief Information<br>on IBED</h1>
                         <p class="elaboration_para">Inspired by the first forum in 2020, and the
                             work of His Holiness the Dalai Lama in the field of inter-faith dialogues, a group of people
@@ -125,7 +125,7 @@
             <div class="section" id="second">
                 <article class="row text-left mx-auto">
                     <img src="../assets/conference/Conference2.png" class="col-md-6 d-none d-lg-block" />
-                    <div class="col-lg-6">
+                    <div class="col-lg-6 content">
                         <div class="vl_left">
                             <h1>Conference<br>Synopsis</h1>
                         </div>


### PR DESCRIPTION
Hello, nothing much to say other than 2 small changes made:

- Fade in for keynote speakers changed from 0.35s to 0.8s
- Changed the timing for brief info and synopsis animation. Text now appears before image
- Learn more about IBED button is no longer animated

Feel free to take a look!